### PR TITLE
apply changes made to the context before suspend to the new context created after resume

### DIFF
--- a/bpm-engine-impl/src/main/java/io/takari/bpm/actions/CreateEventAction.java
+++ b/bpm-engine-impl/src/main/java/io/takari/bpm/actions/CreateEventAction.java
@@ -1,5 +1,6 @@
 package io.takari.bpm.actions;
 
+import io.takari.bpm.context.Change;
 import io.takari.bpm.misc.CoverageIgnore;
 import io.takari.bpm.model.IntermediateCatchEvent;
 
@@ -17,7 +18,7 @@ public class CreateEventAction implements Action {
     private final String timeDuration;
     private final Object payload;
     private final boolean resumeFromSameStep;
-    private final Map<String, Object> resumeVars;
+    private final Map<String, Change> ctxChangesBeforeSuspend;
 
     public CreateEventAction(String definitionId, IntermediateCatchEvent ev) {
         this(definitionId, ev.getId(), ev.getMessageRef(), ev.getMessageRefExpression(),
@@ -35,9 +36,8 @@ public class CreateEventAction implements Action {
     }
 
     public CreateEventAction(String definitionId, String elementId, String messageRef,
-                             String messageRefExpression, String timeDate, String timeDuration,
-                             Object payload, boolean resumeFromSameStep,
-                             Map<String, Object> resumeVars) {
+                String messageRefExpression, String timeDate, String timeDuration,
+                Object payload, boolean resumeFromSameStep, Map<String, Change> ctxChangesBeforeSuspend) {
 
         this.definitionId = definitionId;
         this.elementId = elementId;
@@ -47,7 +47,7 @@ public class CreateEventAction implements Action {
         this.timeDuration = timeDuration;
         this.payload = payload;
         this.resumeFromSameStep = resumeFromSameStep;
-        this.resumeVars = resumeVars;
+        this.ctxChangesBeforeSuspend = ctxChangesBeforeSuspend;
     }
 
     public String getDefinitionId() {
@@ -82,8 +82,8 @@ public class CreateEventAction implements Action {
         return resumeFromSameStep;
     }
 
-    public Map<String, Object> getResumeVars() {
-        return resumeVars;
+    public Map<String, Change> getCtxChangesBeforeSuspend() {
+        return ctxChangesBeforeSuspend;
     }
 
     @Override
@@ -98,7 +98,7 @@ public class CreateEventAction implements Action {
                 ", timeDuration=" + timeDuration +
                 ", payload=" + payload +
                 ", resumeFromSameStep=" + resumeFromSameStep +
-                ", resumeVars=" + resumeVars +
+                ", ctxChangesBeforeSuspend=" + ctxChangesBeforeSuspend +
                 ']';
     }
 }

--- a/bpm-engine-impl/src/main/java/io/takari/bpm/actions/EvalExpressionAction.java
+++ b/bpm-engine-impl/src/main/java/io/takari/bpm/actions/EvalExpressionAction.java
@@ -1,6 +1,7 @@
 package io.takari.bpm.actions;
 
 import io.takari.bpm.commands.Command;
+import io.takari.bpm.context.Change;
 import io.takari.bpm.misc.CoverageIgnore;
 import io.takari.bpm.model.ExpressionType;
 import io.takari.bpm.model.VariableMapping;
@@ -25,10 +26,11 @@ public class EvalExpressionAction implements Action {
     private final Set<VariableMapping> in;
     private final Set<VariableMapping> out;
     private final boolean copyAllVariables;
+    private final Map<String, Change> ctxChanges;
 
     private EvalExpressionAction(String definitionId, String elementId, ExpressionType type, String expression,
                                  Command defaultCommand, List<Timeout<Command>> timeouts, Command defaultError, Map<String, Command> errors,
-                                 Set<VariableMapping> in, Set<VariableMapping> out, boolean copyAllVariables) {
+                                 Set<VariableMapping> in, Set<VariableMapping> out, boolean copyAllVariables,  Map<String, Change> ctxChanges) {
         this.definitionId = definitionId;
         this.elementId = elementId;
         this.type = type;
@@ -40,6 +42,7 @@ public class EvalExpressionAction implements Action {
         this.in = in;
         this.out = out;
         this.copyAllVariables = copyAllVariables;
+        this.ctxChanges = ctxChanges;
     }
 
     public String getDefinitionId() {
@@ -86,6 +89,10 @@ public class EvalExpressionAction implements Action {
         return copyAllVariables;
     }
 
+    public Map<String, Change> getCtxChanges() {
+        return ctxChanges;
+    }
+
     @Override
     @CoverageIgnore
     public String toString() {
@@ -101,6 +108,7 @@ public class EvalExpressionAction implements Action {
                 ", in=" + in +
                 ", out=" + out +
                 ", copyAllVariables=" + copyAllVariables +
+                ", ctxChanges=" + ctxChanges +
                 ']';
     }
 
@@ -118,6 +126,7 @@ public class EvalExpressionAction implements Action {
         private Set<VariableMapping> in;
         private Set<VariableMapping> out;
         private boolean copyAllVariables;
+        private Map<String, Change> changes;
 
         public Builder(String definitionId, String elementId, ExpressionType type, String expression, Command defaultCommand) {
             this.definitionId = definitionId;
@@ -157,8 +166,13 @@ public class EvalExpressionAction implements Action {
             return this;
         }
 
+        public Builder withChanges(Map<String, Change> changes) {
+            this.changes = changes;
+            return this;
+        }
+
         public EvalExpressionAction build() {
-            return new EvalExpressionAction(definitionId, elementId, type, expression, defaultCommand, timeouts, defaultError, errors, in, out, copyAllVariables);
+            return new EvalExpressionAction(definitionId, elementId, type, expression, defaultCommand, timeouts, defaultError, errors, in, out, copyAllVariables, changes);
         }
     }
 }

--- a/bpm-engine-impl/src/main/java/io/takari/bpm/commands/ResumeElementCommand.java
+++ b/bpm-engine-impl/src/main/java/io/takari/bpm/commands/ResumeElementCommand.java
@@ -1,20 +1,22 @@
 package io.takari.bpm.commands;
 
+import io.takari.bpm.context.Change;
+
 import java.util.Map;
 
 public class ResumeElementCommand extends ProcessElementCommand {
 
     private static final long serialVersionUID = 1L;
 
-    private final Map<String, Object> input;
+    private final Map<String, Change> ctxChangesBeforeSuspend;
 
-    public ResumeElementCommand(String definitionId, String elementId, Map<String, Object> input) {
+    public ResumeElementCommand(String definitionId, String elementId, Map<String, Change> ctxChangesBeforeSuspend) {
         super(definitionId, elementId);
 
-        this.input = input;
+        this.ctxChangesBeforeSuspend = ctxChangesBeforeSuspend;
     }
 
-    public Map<String, Object> getInput() {
-        return input;
+    public Map<String, Change> getCtxChangesBeforeSuspend() {
+        return ctxChangesBeforeSuspend;
     }
 }

--- a/bpm-engine-impl/src/main/java/io/takari/bpm/context/ContextUtils.java
+++ b/bpm-engine-impl/src/main/java/io/takari/bpm/context/ContextUtils.java
@@ -8,10 +8,6 @@ import io.takari.bpm.state.ProcessInstance;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.Map;
-
 public final class ContextUtils {
 
     private static final Logger log = LoggerFactory.getLogger(ContextUtils.class);
@@ -38,24 +34,10 @@ public final class ContextUtils {
             log.debug("handleSuspend ['{}'] -> suspend is requested '{}'", state.getBusinessKey(), messageRef);
             stack = stack.push(new PerformActionsCommand(
                     new CreateEventAction(definitionId, elementId, messageRef, null, null, null, ctx.getSuspendPayload(),
-                            ctx.isResumeFromSameStep(), changesToVariablesMap(ctx.getChanges()))));
+                            ctx.isResumeFromSameStep(), ctx.changes())));
         }
 
         return state.setStack(stack);
-    }
-
-    private static Map<String, Object> changesToVariablesMap(Map<String, Change> changes) {
-        if (changes.isEmpty()) {
-            return Collections.emptyMap();
-        }
-
-        Map<String, Object> result = new HashMap<>();
-        for (Map.Entry<String, Change> e : changes.entrySet()) {
-            if (e.getValue().getType() == ChangeType.SET) {
-                result.put(e.getKey(), e.getValue().getValue());
-            }
-        }
-        return result;
     }
 
     private ContextUtils() {

--- a/bpm-engine-impl/src/main/java/io/takari/bpm/context/ExecutionContextImpl.java
+++ b/bpm-engine-impl/src/main/java/io/takari/bpm/context/ExecutionContextImpl.java
@@ -110,10 +110,6 @@ public class ExecutionContextImpl implements ExecutionContext {
         return actions;
     }
 
-    public Map<String, Change> getChanges() {
-        return changes;
-    }
-
     public Variables toVariables() {
         Variables dst = source;
 
@@ -190,6 +186,14 @@ public class ExecutionContextImpl implements ExecutionContext {
     @Override
     public String getElementId() {
         return elementId;
+    }
+
+    public Map<String, Change> changes() {
+        return changes;
+    }
+
+    public void addChanges(Map<String, Change> changes) {
+        this.changes.putAll(changes);
     }
 
     private static List<Variables> stack(Variables tail) {

--- a/bpm-engine-impl/src/main/java/io/takari/bpm/reducers/EventsReducer.java
+++ b/bpm-engine-impl/src/main/java/io/takari/bpm/reducers/EventsReducer.java
@@ -60,7 +60,7 @@ public class EventsReducer implements Reducer {
 
         // evaluate the following element after the event
         if (a.isResumeFromSameStep()) {
-            cmds.add(new ResumeElementCommand(pd.getId(), a.getElementId(), a.getResumeVars()));
+            cmds.add(new ResumeElementCommand(pd.getId(), a.getElementId(), a.getCtxChangesBeforeSuspend()));
         } else {
             cmds.add(new ProcessElementCommand(pd.getId(), next.getId()));
         }

--- a/bpm-engine-impl/src/main/java/io/takari/bpm/reducers/ExpressionsReducer.java
+++ b/bpm-engine-impl/src/main/java/io/takari/bpm/reducers/ExpressionsReducer.java
@@ -54,6 +54,10 @@ public class ExpressionsReducer extends BpmnErrorHandlingReducer {
             Variables vars = VariablesHelper.applyInVariables(contextFactory, state.getVariables(), a.getIn(), a.isCopyAllVariables());
             ctx = contextFactory.create(vars, a.getDefinitionId(), a.getElementId());
 
+            if (a.getCtxChanges() != null) {
+                ctx.addChanges(a.getCtxChanges());
+            }
+
             boolean storeResult = cfg.isStoreExpressionEvalResultsInContext();
             Callable<Command> fn = new DelegateFn(javaDelegateHandler, ctx, a.getType(), a.getExpression(), a.getDefaultCommand(), storeResult);
 


### PR DESCRIPTION
The idea was to pass changes made before "suspend" as input parameters during "resume." 
But since input parameters aren't saved in the process state, those changes are lost.

So now we save the changes before "suspend", apply them during "resume", and for bpm-engine it looks like the task was done without any suspend/resume